### PR TITLE
Implementa tarefa do tipo AmazonTaskProxyless no provider CapMonster.

### DIFF
--- a/src/Provider/CapMonster/Amazon.php
+++ b/src/Provider/CapMonster/Amazon.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Crawly\CaptchaBreaker\Provider\CapMonster;
+
+use Crawly\CaptchaBreaker\Provider\ProviderInterface;
+
+class Amazon extends CapMonster implements ProviderInterface
+{
+    private $websiteURL;
+    private $challengeScript;
+    private $captchaScript;
+    private $websiteKey;
+    private $context;
+    private $iv;
+    private $cookieSolution;
+    public function __construct(
+        string $websiteURL,
+        string $challengeScript,
+        string $captchaScript,
+        string $websiteKey,
+        string $context,
+        string $iv,
+        bool $cookieSolution
+    ) {
+        $this->websiteURL = $websiteURL;
+        $this->challengeScript = $challengeScript;
+        $this->captchaScript = $captchaScript;
+        $this->websiteKey = $websiteKey;
+        $this->context = $context;
+        $this->iv = $iv;
+        $this->cookieSolution = $cookieSolution;
+        parent::__construct();
+    }
+
+    protected function getPostData(): array
+    {
+        return [
+            'type' => 'AmazonTaskProxyless',
+            'websiteURL' => $this->websiteURL,
+            'challengeScript' => $this->challengeScript,
+            'captchaScript' => $this->captchaScript,
+            'websiteKey' => $this->websiteKey,
+            'context' => $this->context,
+            'iv' => $this->iv,
+            'cookieSolution' => $this->cookieSolution,
+        ];
+    }
+
+    public function solve(): string
+    {
+        $this->createTask();
+        $this->waitForResult();
+
+        return $this->taskInfo->solution->cookies->{'aws-waf-token'};
+    }
+
+    public function balance(): float
+    {
+        return $this->getBalance();
+    }
+}

--- a/tests/CapMonster/AmazonTest.php
+++ b/tests/CapMonster/AmazonTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Crawly\CaptchaBreaker\Test\CapMonster;
+
+use Crawly\CaptchaBreaker\Provider\CapMonster\Amazon;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+class AmazonTest extends TestCase
+{
+    public function testGetPostData() {
+        // given
+        $mock = $this->getMockBuilder(Amazon::class)
+            ->setConstructorArgs([
+                'websiteURL phpunit',
+                'challengeScript crawly',
+                'captchaScript phpunit',
+                'websiteKey crawly',
+                'context phpunit',
+                'iv crawly',
+                true
+            ])
+            ->getMock();
+        $stub = $this->getNoCaptchaReflection();
+        $getPostDataMethod = $this->getPostDataMethod($stub);
+
+        // when
+        $postData = $getPostDataMethod->invoke($mock);
+
+        // then
+        $this->assertEquals('AmazonTaskProxyless', $postData['type']);
+        $this->assertEquals('websiteURL phpunit', $postData['websiteURL']);
+        $this->assertEquals('challengeScript crawly', $postData['challengeScript']);
+        $this->assertEquals('captchaScript phpunit', $postData['captchaScript']);
+        $this->assertEquals('websiteKey crawly', $postData['websiteKey']);
+        $this->assertEquals('context phpunit', $postData['context']);
+        $this->assertEquals('iv crawly', $postData['iv']);
+        $this->assertTrue($postData['cookieSolution']);
+    }
+    private function getNoCaptchaReflection(): ReflectionClass
+    {
+        return new ReflectionClass(Amazon::class);
+    }
+    private function getPostDataMethod(ReflectionClass $stub): \ReflectionMethod
+    {
+        $getPostData = $stub->getMethod('getPostData');
+        $getPostData->setAccessible(true);
+
+        return $getPostData;
+    }
+}


### PR DESCRIPTION
# Descrição

Durante análise da issue relacionada crawly/produto#1184, verificou-se a utilização do captcha [AWS WAF Captcha and Challenge](https://docs.capmonster.cloud/docs/captchas/amazon-task).
Esse PR implementa apenas a criação da tarefa no provider [CapMonster](https://docs.capmonster.cloud/docs/captchas/amazon-task) porque não foi possível encontrar um equivalente no provider [AntiCaptcha](https://anti-captcha.com/apidoc).

# Relacionado
- crawly/produto#1184