### PR TITLE
Adiciona clientKey obrigatório.

### DIFF
--- a/src/Provider/CapMonster/Amazon.php
+++ b/src/Provider/CapMonster/Amazon.php
@@ -14,6 +14,7 @@ class Amazon extends CapMonster implements ProviderInterface
     private $iv;
     private $cookieSolution;
     public function __construct(
+        string $clientKey,
         string $websiteURL,
         string $challengeScript,
         string $captchaScript,
@@ -22,6 +23,7 @@ class Amazon extends CapMonster implements ProviderInterface
         string $iv,
         bool $cookieSolution
     ) {
+        $this->clientKey  = $clientKey;
         $this->websiteURL = $websiteURL;
         $this->challengeScript = $challengeScript;
         $this->captchaScript = $captchaScript;

--- a/tests/CapMonster/AmazonTest.php
+++ b/tests/CapMonster/AmazonTest.php
@@ -12,6 +12,7 @@ class AmazonTest extends TestCase
         // given
         $mock = $this->getMockBuilder(Amazon::class)
             ->setConstructorArgs([
+                'clientKey',
                 'websiteURL phpunit',
                 'challengeScript crawly',
                 'captchaScript phpunit',


### PR DESCRIPTION
# Descrição

No [PR do captcha da Amazon](https://github.com/crawly/captcha-breaker/pull/11) ficou faltando receber _clientKey_ no construtor.