### PR TITLE
Implementa captcha TenDI

### DIFF
--- a/src/Exception/DeprecatedMethod.php
+++ b/src/Exception/DeprecatedMethod.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Crawly\CaptchaBreaker\Exception;
+
+use Exception;
+
+class DeprecatedMethod extends Exception
+{
+    //
+}

--- a/src/Provider/AntiCaptcha/HCaptcha.php
+++ b/src/Provider/AntiCaptcha/HCaptcha.php
@@ -1,9 +1,9 @@
 <?php
 
-
 namespace Crawly\CaptchaBreaker\Provider\AntiCaptcha;
 
 use Crawly\CaptchaBreaker\Provider\ProviderInterface;
+use Crawly\CaptchaBreaker\ValueObject\ChallengeResponse;
 use Psr\Log\LoggerInterface;
 
 class HCaptcha extends AntiCaptcha implements ProviderInterface
@@ -78,10 +78,20 @@ class HCaptcha extends AntiCaptcha implements ProviderInterface
      */
     public function solve(): string
     {
+        return $this->resolveChallenge()
+            ->getResult();
+    }
+
+    /**
+     * {@inheritDoc}
+     * @codeCoverageIgnore
+     */
+    public function resolveChallenge(): ChallengeResponse
+    {
         $this->createTask();
         $this->waitForResult();
 
-        return $this->getTaskSolution();
+        return new ChallengeResponse($this->getTaskSolution());
     }
 
     /**

--- a/src/Provider/AntiCaptcha/ImageToText.php
+++ b/src/Provider/AntiCaptcha/ImageToText.php
@@ -4,6 +4,7 @@
 namespace Crawly\CaptchaBreaker\Provider\AntiCaptcha;
 
 use Crawly\CaptchaBreaker\Provider\ProviderInterface;
+use Crawly\CaptchaBreaker\ValueObject\ChallengeResponse;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -76,10 +77,20 @@ class ImageToText extends AntiCaptcha implements ProviderInterface
      */
     public function solve(): string
     {
+        return $this->resolveChallenge()
+            ->getResult();
+    }
+
+    /**
+     * {@inheritDoc}
+     * @codeCoverageIgnore
+     */
+    public function resolveChallenge(): ChallengeResponse
+    {
         $this->createTask();
         $this->waitForResult();
 
-        return $this->getTaskSolution();
+        return new ChallengeResponse($this->getTaskSolution());
     }
 
     /**

--- a/src/Provider/AntiCaptcha/NoCaptcha.php
+++ b/src/Provider/AntiCaptcha/NoCaptcha.php
@@ -4,6 +4,7 @@
 namespace Crawly\CaptchaBreaker\Provider\AntiCaptcha;
 
 use Crawly\CaptchaBreaker\Provider\ProviderInterface;
+use Crawly\CaptchaBreaker\ValueObject\ChallengeResponse;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -104,10 +105,20 @@ class NoCaptcha extends AntiCaptcha implements ProviderInterface
      */
     public function solve(): string
     {
+        return $this->resolveChallenge()
+            ->getResult();
+    }
+
+    /**
+     * {@inheritDoc}
+     * @codeCoverageIgnore
+     */
+    public function resolveChallenge(): ChallengeResponse
+    {
         $this->createTask();
         $this->waitForResult();
 
-        return $this->getTaskSolution();
+        return new ChallengeResponse($this->getTaskSolution());
     }
 
     /**

--- a/src/Provider/AntiCaptcha/ReCaptchaV3.php
+++ b/src/Provider/AntiCaptcha/ReCaptchaV3.php
@@ -1,9 +1,9 @@
 <?php
 
-
 namespace Crawly\CaptchaBreaker\Provider\AntiCaptcha;
 
 use Crawly\CaptchaBreaker\Provider\ProviderInterface;
+use Crawly\CaptchaBreaker\ValueObject\ChallengeResponse;
 use Psr\Log\LoggerInterface;
 
 class ReCaptchaV3 extends AntiCaptcha implements ProviderInterface
@@ -66,10 +66,20 @@ class ReCaptchaV3 extends AntiCaptcha implements ProviderInterface
      */
     public function solve(): string
     {
+        return $this->resolveChallenge()
+            ->getResult();
+    }
+
+    /**
+     * {@inheritDoc}
+     * @codeCoverageIgnore
+     */
+    public function resolveChallenge(): ChallengeResponse
+    {
         $this->createTask();
         $this->waitForResult();
 
-        return $this->getTaskSolution();
+        return new ChallengeResponse($this->getTaskSolution());
     }
 
     /**

--- a/src/Provider/AntiCaptcha/TurnstileCaptcha.php
+++ b/src/Provider/AntiCaptcha/TurnstileCaptcha.php
@@ -4,6 +4,7 @@
 namespace Crawly\CaptchaBreaker\Provider\AntiCaptcha;
 
 use Crawly\CaptchaBreaker\Provider\ProviderInterface;
+use Crawly\CaptchaBreaker\ValueObject\ChallengeResponse;
 use Psr\Log\LoggerInterface;
 
 class TurnstileCaptcha extends AntiCaptcha implements ProviderInterface
@@ -74,10 +75,20 @@ class TurnstileCaptcha extends AntiCaptcha implements ProviderInterface
      */
     public function solve(): string
     {
+        return $this->resolveChallenge()
+            ->getResult();
+    }
+
+    /**
+     * {@inheritDoc}
+     * @codeCoverageIgnore
+     */
+    public function resolveChallenge(): ChallengeResponse
+    {
         $this->createTask();
         $this->waitForResult();
 
-        return $this->getTaskSolution();
+        return new ChallengeResponse($this->getTaskSolution());
     }
 
     /**

--- a/src/Provider/CapMonster/Amazon.php
+++ b/src/Provider/CapMonster/Amazon.php
@@ -3,6 +3,7 @@
 namespace Crawly\CaptchaBreaker\Provider\CapMonster;
 
 use Crawly\CaptchaBreaker\Provider\ProviderInterface;
+use Crawly\CaptchaBreaker\ValueObject\ChallengeResponse;
 
 class Amazon extends CapMonster implements ProviderInterface
 {
@@ -48,12 +49,28 @@ class Amazon extends CapMonster implements ProviderInterface
         ];
     }
 
+    /**
+     * {@inheritDoc}
+     * @codeCoverageIgnore
+     */
     public function solve(): string
+    {
+        return $this->resolveChallenge()
+            ->getResult();
+    }
+
+    /**
+     * {@inheritDoc}
+     * @codeCoverageIgnore
+     */
+    public function resolveChallenge(): ChallengeResponse
     {
         $this->createTask();
         $this->waitForResult();
 
-        return $this->taskInfo->solution->cookies->{'aws-waf-token'};
+        return new ChallengeResponse(
+            $this->taskInfo->solution->cookies->{'aws-waf-token'}
+        );
     }
 
     public function balance(): float

--- a/src/Provider/CapMonster/HCaptcha.php
+++ b/src/Provider/CapMonster/HCaptcha.php
@@ -4,6 +4,7 @@
 namespace Crawly\CaptchaBreaker\Provider\CapMonster;
 
 use Crawly\CaptchaBreaker\Provider\ProviderInterface;
+use Crawly\CaptchaBreaker\ValueObject\ChallengeResponse;
 use Psr\Log\LoggerInterface;
 
 class HCaptcha extends CapMonster implements ProviderInterface
@@ -78,10 +79,20 @@ class HCaptcha extends CapMonster implements ProviderInterface
      */
     public function solve(): string
     {
+        return $this->resolveChallenge()
+            ->getResult();
+    }
+
+    /**
+     * {@inheritDoc}
+     * @codeCoverageIgnore
+     */
+    public function resolveChallenge(): ChallengeResponse
+    {
         $this->createTask();
         $this->waitForResult();
 
-        return $this->getTaskSolution();
+        return new ChallengeResponse($this->getTaskSolution());
     }
 
     /**

--- a/src/Provider/CapMonster/ImageToText.php
+++ b/src/Provider/CapMonster/ImageToText.php
@@ -1,9 +1,9 @@
 <?php
 
-
 namespace Crawly\CaptchaBreaker\Provider\CapMonster;
 
 use Crawly\CaptchaBreaker\Provider\ProviderInterface;
+use Crawly\CaptchaBreaker\ValueObject\ChallengeResponse;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -76,10 +76,20 @@ class ImageToText extends CapMonster implements ProviderInterface
      */
     public function solve(): string
     {
+        return $this->resolveChallenge()
+            ->getResult();
+    }
+
+    /**
+     * {@inheritDoc}
+     * @codeCoverageIgnore
+     */
+    public function resolveChallenge(): ChallengeResponse
+    {
         $this->createTask();
         $this->waitForResult();
 
-        return $this->getTaskSolution();
+        return new ChallengeResponse($this->getTaskSolution());
     }
 
     /**

--- a/src/Provider/CapMonster/NoCaptcha.php
+++ b/src/Provider/CapMonster/NoCaptcha.php
@@ -4,6 +4,7 @@
 namespace Crawly\CaptchaBreaker\Provider\CapMonster;
 
 use Crawly\CaptchaBreaker\Provider\ProviderInterface;
+use Crawly\CaptchaBreaker\ValueObject\ChallengeResponse;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -100,10 +101,20 @@ class NoCaptcha extends CapMonster implements ProviderInterface
      */
     public function solve(): string
     {
+        return $this->resolveChallenge()
+            ->getResult();
+    }
+
+    /**
+     * {@inheritDoc}
+     * @codeCoverageIgnore
+     */
+    public function resolveChallenge(): ChallengeResponse
+    {
         $this->createTask();
         $this->waitForResult();
 
-        return $this->getTaskSolution();
+        return new ChallengeResponse($this->getTaskSolution());
     }
 
     /**

--- a/src/Provider/CapMonster/ReCaptchaV3.php
+++ b/src/Provider/CapMonster/ReCaptchaV3.php
@@ -4,6 +4,7 @@
 namespace Crawly\CaptchaBreaker\Provider\CapMonster;
 
 use Crawly\CaptchaBreaker\Provider\ProviderInterface;
+use Crawly\CaptchaBreaker\ValueObject\ChallengeResponse;
 use Psr\Log\LoggerInterface;
 
 class ReCaptchaV3 extends CapMonster implements ProviderInterface
@@ -62,10 +63,20 @@ class ReCaptchaV3 extends CapMonster implements ProviderInterface
      */
     public function solve(): string
     {
+        return $this->resolveChallenge()
+            ->getResult();
+    }
+
+    /**
+     * {@inheritDoc}
+     * @codeCoverageIgnore
+     */
+    public function resolveChallenge(): ChallengeResponse
+    {
         $this->createTask();
         $this->waitForResult();
 
-        return $this->getTaskSolution();
+        return new ChallengeResponse($this->getTaskSolution());
     }
 
     /**

--- a/src/Provider/CapMonster/TendiCaptcha.php
+++ b/src/Provider/CapMonster/TendiCaptcha.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Crawly\CaptchaBreaker\Provider\CapMonster;
+
+use Crawly\CaptchaBreaker\Exception\DeprecatedMethod;
+use Crawly\CaptchaBreaker\Provider\ProviderInterface;
+use Crawly\CaptchaBreaker\ValueObject\TendiChallengeResponse;
+use Psr\Log\LoggerInterface;
+
+class TendiCaptcha extends CapMonster implements ProviderInterface
+{
+    private $websiteURL;
+    private $websiteKey;
+
+    public function __construct(
+        string $clientKey,
+        string $websiteURL,
+        string $websiteKey,
+        LoggerInterface $logger = null
+    ) {
+        $this->clientKey  = $clientKey;
+        $this->websiteURL = $websiteURL;
+        $this->websiteKey = $websiteKey;
+        $this->logger = $logger;
+
+        parent::__construct();
+    }
+
+    protected function getPostData(): array
+    {
+        return [
+            'type'       => 'CustomTask',
+            'class'      => 'TenDI',
+            'websiteURL' => $this->websiteURL,
+            'websiteKey' => $this->websiteKey,
+        ];
+    }
+
+    /**
+     * {@inheritDoc}
+     * @throws DeprecatedMethod
+     * @codeCoverageIgnore
+     */
+    public function solve(): string
+    {
+        throw new DeprecatedMethod(
+            'Method "solve" is deprecated and should not be used, use "resolveChallenge" instead.'
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     * @codeCoverageIgnore
+     */
+    public function resolveChallenge(): TendiChallengeResponse
+    {
+        $this->createTask();
+        $this->waitForResult();
+
+        return new TendiChallengeResponse(
+            $this->taskInfo->solution->data->ticket,
+            $this->taskInfo->solution->data->randstr,
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     * @codeCoverageIgnore
+     */
+    public function balance(): float
+    {
+        return $this->getBalance();
+    }
+
+    /**
+     * Send complaint on an incorrectly solved captcha.
+     *
+     * @return bool
+     * @codeCoverageIgnore
+     */
+    public function reportIncorrectCaptcha(): bool
+    {
+        return $this->reportIncorrect($this->getTaskId());
+    }
+}

--- a/src/Provider/CapMonster/TurnstileCaptcha.php
+++ b/src/Provider/CapMonster/TurnstileCaptcha.php
@@ -3,6 +3,7 @@
 namespace Crawly\CaptchaBreaker\Provider\CapMonster;
 
 use Crawly\CaptchaBreaker\Provider\ProviderInterface;
+use Crawly\CaptchaBreaker\ValueObject\ChallengeResponse;
 use Psr\Log\LoggerInterface;
 
 class TurnstileCaptcha extends CapMonster implements ProviderInterface
@@ -77,10 +78,20 @@ class TurnstileCaptcha extends CapMonster implements ProviderInterface
      */
     public function solve(): string
     {
+        return $this->resolveChallenge()
+            ->getResult();
+    }
+
+    /**
+     * {@inheritDoc}
+     * @codeCoverageIgnore
+     */
+    public function resolveChallenge(): ChallengeResponse
+    {
         $this->createTask();
         $this->waitForResult();
 
-        return $this->getTaskSolution();
+        return new ChallengeResponse($this->getTaskSolution());
     }
 
     /**

--- a/src/Provider/ProviderInterface.php
+++ b/src/Provider/ProviderInterface.php
@@ -1,20 +1,28 @@
 <?php
 
-
 namespace Crawly\CaptchaBreaker\Provider;
 
 use Crawly\CaptchaBreaker\Exception\BalanceFailedException;
 use Crawly\CaptchaBreaker\Exception\BreakFailedException;
 use Crawly\CaptchaBreaker\Exception\TaskCreationFailedException;
+use Crawly\CaptchaBreaker\ValueObject\ChallengeResponseContract;
 
 interface ProviderInterface
 {
     /**
+     * @deprecated You should use resolveChallenge instead.
      * @return string
      * @throws TaskCreationFailedException If the captcha breaker provider throws a task creation exception.
      * @throws BreakFailedException
      */
     public function solve(): string;
+
+    /**
+     * @return ChallengeResponseContract
+     * @throws TaskCreationFailedException If the captcha breaker provider throws a task creation exception.
+     * @throws BreakFailedException
+     */
+    public function resolveChallenge(): ChallengeResponseContract;
 
     /**
      * @return float

--- a/src/ValueObject/ChallengeResponse.php
+++ b/src/ValueObject/ChallengeResponse.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Crawly\CaptchaBreaker\ValueObject;
+
+class ChallengeResponse implements ChallengeResponseContract
+{
+    protected $result;
+
+    public function __construct(string $result)
+    {
+        $this->result = $result;
+    }
+
+    public function getResult(): string
+    {
+        return $this->result;
+    }
+}

--- a/src/ValueObject/ChallengeResponseContract.php
+++ b/src/ValueObject/ChallengeResponseContract.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Crawly\CaptchaBreaker\ValueObject;
+
+interface ChallengeResponseContract
+{
+    //
+}

--- a/src/ValueObject/TendiChallengeResponse.php
+++ b/src/ValueObject/TendiChallengeResponse.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Crawly\CaptchaBreaker\ValueObject;
+
+class TendiChallengeResponse implements ChallengeResponseContract
+{
+    protected $ticket;
+
+    protected $randomString;
+
+    public function __construct(string $ticket, string $randomString)
+    {
+        $this->ticket = $ticket;
+        $this->randomString = $randomString;
+    }
+
+    public function getTicket(): string
+    {
+        return $this->ticket;
+    }
+
+    public function getRandomString(): string
+    {
+        return $this->randomString;
+    }
+}


### PR DESCRIPTION
Este PR implementa a classe necessária para resolução do captcha TenDI através do [Capmonster](https://docs.capmonster.cloud/docs/captchas/tendi/).

O captcha TenDI exige o envio de dois parâmetros, o `ticket` e o `randomString`. Para que isso fosse possível implementamos um novo método `getChallenge`, retornando objetos como resposta.

Marcamos o método `solve` como deprecated, sugerindo a adoção do novo método no lugar.

Fix https://github.com/crawly/produto/issues/1182

