### PR TITLE
Corrige o parsing da resposta do Cloudflare Challenge

### DIFF
--- a/src/ValueObject/CloudflareChallengeResponse.php
+++ b/src/ValueObject/CloudflareChallengeResponse.php
@@ -5,9 +5,8 @@ namespace Crawly\CaptchaBreaker\ValueObject;
 class CloudflareChallengeResponse implements ChallengeResponseContract
 {
     private string $cloudflareClearance;
-    private string $token;
 
-    public function __construct(string $cloudflareClearance, string $token)
+    public function __construct(string $cloudflareClearance)
     {
         if (empty(trim($cloudflareClearance))) {
             throw new \InvalidArgumentException(
@@ -15,21 +14,11 @@ class CloudflareChallengeResponse implements ChallengeResponseContract
             );
         }
 
-        if (empty(trim($token))) {
-            throw new \InvalidArgumentException("Token cannot be empty");
-        }
-
         $this->cloudflareClearance = $cloudflareClearance;
-        $this->token = $token;
     }
 
     public function getCloudflareClearance(): string
     {
         return $this->cloudflareClearance;
-    }
-
-    public function getToken(): string
-    {
-        return $this->token;
     }
 }

--- a/tests/ValueObject/CloudflareChallengeResponseTest.php
+++ b/tests/ValueObject/CloudflareChallengeResponseTest.php
@@ -10,22 +10,12 @@ class CloudflareChallengeResponseTest extends TestCase
     public function testGetCloudflareClearance(): void
     {
         $cloudflareChallengeResponse = new CloudflareChallengeResponse(
-            "cloudflare-clearance",
-            "token"
+            "cloudflare-clearance"
         );
         $this->assertEquals(
             "cloudflare-clearance",
             $cloudflareChallengeResponse->getCloudflareClearance()
         );
-    }
-
-    public function testGetToken(): void
-    {
-        $cloudflareChallengeResponse = new CloudflareChallengeResponse(
-            "cloudflare-clearance",
-            "token"
-        );
-        $this->assertEquals("token", $cloudflareChallengeResponse->getToken());
     }
 
     /**
@@ -34,12 +24,11 @@ class CloudflareChallengeResponseTest extends TestCase
     public function validationProvider(): array
     {
         return [
-            ["", "token", "Cloudflare clearance cannot be empty"],
-            ["cloudflare-clearance", "", "Token cannot be empty"],
-            ["", "", "Cloudflare clearance cannot be empty"],
-            [" ", " ", "Cloudflare clearance cannot be empty"],
-            ["\t", "\t", "Cloudflare clearance cannot be empty"],
-            ["\n", "\n", "Cloudflare clearance cannot be empty"],
+            ["", "Cloudflare clearance cannot be empty"],
+            ["", "Cloudflare clearance cannot be empty"],
+            [" ", "Cloudflare clearance cannot be empty"],
+            ["\t", "Cloudflare clearance cannot be empty"],
+            ["\n", "Cloudflare clearance cannot be empty"],
         ];
     }
 
@@ -48,11 +37,10 @@ class CloudflareChallengeResponseTest extends TestCase
      */
     public function testValidation(
         string $cloudflareClearance,
-        string $token,
         string $expectedMessage
     ): void {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage($expectedMessage);
-        new CloudflareChallengeResponse($cloudflareClearance, $token);
+        new CloudflareChallengeResponse($cloudflareClearance);
     }
 }


### PR DESCRIPTION
# Descrição

A propriedade token não é retornada na resposta como descrito na [doc](https://docs.capmonster.cloud/docs/captchas/tunrstile-task#gettaskresult).