### PR TITLE
Adiciona novo cookie no Challenge Cloudflare.

### DIFF
--- a/src/Provider/CapMonster/CloudflareChallengeWithCookiesCaptcha.php
+++ b/src/Provider/CapMonster/CloudflareChallengeWithCookiesCaptcha.php
@@ -84,7 +84,8 @@ class CloudflareChallengeWithCookiesCaptcha extends CapMonster implements
         $this->waitForResult();
 
         return new CloudflareChallengeResponse(
-            $this->taskInfo->solution->cf_clearance
+            $this->taskInfo->solution->cf_clearance,
+            $this->taskInfo->solution->_cfuvid
         );
     }
 

--- a/src/ValueObject/CloudflareChallengeResponse.php
+++ b/src/ValueObject/CloudflareChallengeResponse.php
@@ -6,7 +6,7 @@ class CloudflareChallengeResponse implements ChallengeResponseContract
 {
     private string $cloudflareClearance;
 
-    public function __construct(string $cloudflareClearance)
+    public function __construct(string $cloudflareClearance, string $cfuvid)
     {
         if (empty(trim($cloudflareClearance))) {
             throw new \InvalidArgumentException(
@@ -14,11 +14,23 @@ class CloudflareChallengeResponse implements ChallengeResponseContract
             );
         }
 
+        if (empty(trim($cfuvid))) {
+            throw new \InvalidArgumentException(
+                "cfuvid cannot be empty"
+            );
+        }
+
         $this->cloudflareClearance = $cloudflareClearance;
+        $this->cfuvid = $cfuvid;
     }
 
     public function getCloudflareClearance(): string
     {
         return $this->cloudflareClearance;
+    }
+
+    public function getCfuvid(): string
+    {
+        return $this->cfuvid;
     }
 }

--- a/tests/ValueObject/CloudflareChallengeResponseTest.php
+++ b/tests/ValueObject/CloudflareChallengeResponseTest.php
@@ -10,11 +10,17 @@ class CloudflareChallengeResponseTest extends TestCase
     public function testGetCloudflareClearance(): void
     {
         $cloudflareChallengeResponse = new CloudflareChallengeResponse(
-            "cloudflare-clearance"
+            "cloudflare-clearance",
+            "cfuvid"
         );
         $this->assertEquals(
             "cloudflare-clearance",
             $cloudflareChallengeResponse->getCloudflareClearance()
+        );
+
+        $this->assertEquals(
+            "cfuvid",
+            $cloudflareChallengeResponse->getCfuvid()
         );
     }
 
@@ -24,11 +30,20 @@ class CloudflareChallengeResponseTest extends TestCase
     public function validationProvider(): array
     {
         return [
-            ["", "Cloudflare clearance cannot be empty"],
-            ["", "Cloudflare clearance cannot be empty"],
-            [" ", "Cloudflare clearance cannot be empty"],
-            ["\t", "Cloudflare clearance cannot be empty"],
-            ["\n", "Cloudflare clearance cannot be empty"],
+            ["", "", "Cloudflare clearance cannot be empty"],
+            [" ", "", "Cloudflare clearance cannot be empty"],
+            ["\t", "", "Cloudflare clearance cannot be empty"],
+            ["\n", "", "Cloudflare clearance cannot be empty"],
+            ["\r", "", "Cloudflare clearance cannot be empty"],
+            ["\0", "", "Cloudflare clearance cannot be empty"],
+            ["\x0B", "", "Cloudflare clearance cannot be empty"],
+            ["cloudflare-clearance", "", "cfuvid cannot be empty"],
+            ["cloudflare-clearance", " ", "cfuvid cannot be empty"],
+            ["cloudflare-clearance", "\t", "cfuvid cannot be empty"],
+            ["cloudflare-clearance", "\n", "cfuvid cannot be empty"],
+            ["cloudflare-clearance", "\r", "cfuvid cannot be empty"],
+            ["cloudflare-clearance", "\0", "cfuvid cannot be empty"],
+            ["cloudflare-clearance", "\x0B", "cfuvid cannot be empty"],
         ];
     }
 
@@ -37,10 +52,11 @@ class CloudflareChallengeResponseTest extends TestCase
      */
     public function testValidation(
         string $cloudflareClearance,
+        string $cfuvid,
         string $expectedMessage
     ): void {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage($expectedMessage);
-        new CloudflareChallengeResponse($cloudflareClearance);
+        new CloudflareChallengeResponse($cloudflareClearance, $cfuvid);
     }
 }


### PR DESCRIPTION
# Descrição

Na investigação da fonte PF antecedentes criminais, percebemos um novo cookie sendo enviado na requisição.
Solicitamos uma adequação ao provedor e esta implementação inclui essa nova informação.

# Relacionados
- crawly/produto#1259